### PR TITLE
PhantomJSSetup shutdown hook fails when source dir does not exist #9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,12 @@
         <artifactId>slf4j-api</artifactId>
         <version>1.7.25</version>
       </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-simple</artifactId>
+        <version>1.7.25</version>
+        <scope>test</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/wrapper/pom.xml
+++ b/wrapper/pom.xml
@@ -55,5 +55,9 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/wrapper/src/main/java/com/moodysalem/phantomjs/wrapper/PhantomJSSetup.java
+++ b/wrapper/src/main/java/com/moodysalem/phantomjs/wrapper/PhantomJSSetup.java
@@ -198,13 +198,16 @@ class PhantomJSSetup {
 
             @Override
             public void run() {
+                deleteTempDir(PhantomJSConstants.TEMP_SOURCE_DIR);
+                deleteTempDir(PhantomJSConstants.TEMP_SCRIPT_DIR);
+                deleteTempDir(PhantomJSConstants.TEMP_RENDER_DIR);
+            }
+            
+            private void deleteTempDir(Path path) {
                 try {
-                    Files.delete(PhantomJSConstants.TEMP_SOURCE_DIR);
-                    Files.delete(PhantomJSConstants.TEMP_SCRIPT_DIR);
-                    Files.delete(PhantomJSConstants.TEMP_RENDER_DIR);
-
+                    Files.deleteIfExists(path);
                 } catch (final Exception e) {
-                    LOG.warn("PhantomJSSetup was unable to clean up temporary directories under: [{}]. Caused by: ", PhantomJSConstants.TEMP_DIR, e);
+                    LOG.warn("PhantomJSSetup was unable to clean up temporary directory [{}]. Caused by: ", path, e);
                 }
             }
         };


### PR DESCRIPTION
- use Files.deleteIfExists
- add slf4j-simple binding for test scope, so logs messages are visible during test execution